### PR TITLE
DOM with nested sections

### DIFF
--- a/lib/Pod/PseudoPod/DOM.pm
+++ b/lib/Pod/PseudoPod/DOM.pm
@@ -43,7 +43,7 @@ sub parse_string_document
         $self->{formatter_args}{emit_environments} = $environments;
     }
 
-    return $self->SUPER::parse_string_document( $document );
+    $self->SUPER::parse_string_document( $document );
 }
 
 sub _treat_Es

--- a/lib/Pod/PseudoPod/DOM/Elements.pm
+++ b/lib/Pod/PseudoPod/DOM/Elements.pm
@@ -40,6 +40,17 @@ use Moose;
 }
 
 {
+    package Pod::PseudoPod::DOM::Element::Section;
+
+    use Moose;
+    has 'level',
+        is      => 'ro',
+        isa     => 'Num';
+
+    extends 'Pod::PseudoPod::DOM::ParentElement';
+}
+
+{
     package Pod::PseudoPod::DOM::Element::Paragraph;
 
     use Moose;

--- a/lib/Pod/PseudoPod/DOM/Role/XHTML.pm
+++ b/lib/Pod/PseudoPod/DOM/Role/XHTML.pm
@@ -62,6 +62,7 @@ sub emit_body
     return <<END_HTML_HEAD . $self->emit_kids( @_ ) . <<END_HTML;
 <html>
 <head>
+<!-- this will not be valid without a TITLE element -->
 <link rel="stylesheet" href="style.css" type="text/css" />
 </head>
 <body>
@@ -70,6 +71,19 @@ END_HTML_HEAD
 </body>
 </html>
 END_HTML
+}
+
+sub emit_section
+{
+    my $self = shift;
+    return sprintf(
+        # in HTML5, you might want <section> instead of <div>
+        '<div class="%s %s-level-%d">%s</div>',
+        $self->type,
+        $self->type,
+        $self->level + 1,  # in HTML headings, $[ = 1
+        $self->emit_kids,
+        );
 }
 
 sub emit_kids

--- a/lib/Pod/PseudoPod/DOM/WithSections.pm
+++ b/lib/Pod/PseudoPod/DOM/WithSections.pm
@@ -1,0 +1,52 @@
+package Pod::PseudoPod::DOM::WithSections;
+# ABSTRACT: a better object model for Pod::PseudoPod documents
+
+use strict;
+use warnings;
+
+use parent 'Pod::PseudoPod::DOM';
+
+sub parse_string_document
+{
+    my ($self, $document, %args) = @_;
+    $self->SUPER::parse_string_document($document, %args);
+    $self->_section_fixup;
+    return $self;
+}
+
+sub _section_fixup
+{
+    my ($self) = @_;
+    $self->_build_section($self->{Document}, 0);
+#    use Data::Dumper;
+#    print Dumper($self->{Document});
+}
+
+sub _build_section
+{
+    my ($self, $node, $level) = @_;
+    
+    my @children = @{ $node->children || [] };
+    my @adjusted;
+    while (@children) {
+        my $kid = shift @children;
+        
+        if ($kid->type eq 'header' and $kid->level <= $level) {
+            my $section = $self->make(Section => type => 'section', level => $kid->level, children => []);
+            while (@children and not ($children[0]->type eq 'header' and $children[0]->level <= $level)) {
+                $section->add_children(shift @children);
+            }
+            $self->_build_section($section, $level+1);
+            unshift @{ $section->children }, $kid;
+            push @adjusted, $section;
+        } 
+        else {
+            push @adjusted, $kid;
+        }
+    }
+    
+    $node->children(\@adjusted);
+    return $self;
+}
+
+1;


### PR DESCRIPTION
In pseudo-markup, the current DOM represents a document like this:

```
<h1>Example</h1>
<h2>Name</.h2>
<p>...</p>
<h2>Synopsis</h2>
<pre>...</pre>
<h2>Description</h2>
<h3>Constructor</h3>
<ul>...</ul>
<h3>Methods</h3>
<ul>...</ul>
```

The DOM with nested sections uses:

```
<section>
  <h1>Example</h1>
  <section>
    <h2>Name</.h2>
    <p>...</p>
  </section>
  <section>
    <h2>Synopsis</h2>
    <pre>...</pre>
  </section>
  <section>
    <h2>Description</h2>
    <section>
      <h3>Constructor</h3>
      <ul>...</ul>
    </section>
    <section>
      <h3>Methods</h3>
      <ul>...</ul>
    </section>
  </section>
</section>
```

This allows the production of better structured markup, explicitly associating headers with the content that they head.

The code is mostly a proof-of-concept, and doesn't include any test cases.
